### PR TITLE
Add option to ignore SSL certificate errors

### DIFF
--- a/BroadworksConnector/Ocip/SoapTransport.cs
+++ b/BroadworksConnector/Ocip/SoapTransport.cs
@@ -31,11 +31,18 @@ namespace BroadWorksConnector.Ocip
         public SoapTransport(Uri uri, OcipClientOptions ocipOptions)
         {
             _uri = uri;
-            _httpClient = new HttpClient()
+            var handler = new HttpClientHandler();
+
+            if (ocipOptions.IgnoreSslCertificateErrors)
+            {
+                handler.ServerCertificateCustomValidationCallback = (message, cert, chain, errors) => true;
+            }
+
+            _httpClient = new HttpClient(handler)
             {
                 Timeout = ocipOptions.SoapTimeout <= 0
-                    ? Timeout.InfiniteTimeSpan
-                    : TimeSpan.FromMilliseconds(ocipOptions.SoapTimeout)
+                         ? Timeout.InfiniteTimeSpan
+                         : TimeSpan.FromMilliseconds(ocipOptions.SoapTimeout)
             };
         }
 

--- a/BroadworksConnector/OcipClientOptions.cs
+++ b/BroadworksConnector/OcipClientOptions.cs
@@ -54,5 +54,11 @@ namespace BroadWorksConnector
         /// Encoding setting for decoding the request data with TCP transport. Defaults to UTF8.
         /// </summary>
         public Encoding TcpResponseEncoding { get; set; } = Encoding.UTF8;
+
+        /// <summary>
+        /// Whether to ignore the Ssl certificate errors which can happen when working against a server with expired certificate. 
+        /// Defaults to false.
+        /// </summary>
+        public bool IgnoreSslCertificateErrors { get; set; } = false;
     }
 }


### PR DESCRIPTION
Modified SoapTransport constructor to include an option to ignore SSL certificate errors by adding a new HttpClientHandler with ServerCertificateCustomValidationCallback. Updated _httpClient initialization to use this handler. Added IgnoreSslCertificateErrors property in OcipClientOptions with a default value of false.
This option is required when working against a server that has an expired certificate.  When setting the flag to true the exception that is thrown within the OcipClient is not thrown and the connection to the server can be created